### PR TITLE
Improve tasks example

### DIFF
--- a/tasks/quickstart/quickstart.go
+++ b/tasks/quickstart/quickstart.go
@@ -63,10 +63,10 @@ func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
 // Retrieves a token from a local file.
 func tokenFromFile(file string) (*oauth2.Token, error) {
 	f, err := os.Open(file)
-	defer f.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	tok := &oauth2.Token{}
 	err = json.NewDecoder(f).Decode(tok)
 	return tok, err
@@ -76,10 +76,10 @@ func tokenFromFile(file string) (*oauth2.Token, error) {
 func saveToken(path string, token *oauth2.Token) {
 	fmt.Printf("Saving credential file to: %s\n", path)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	defer f.Close()
 	if err != nil {
 		log.Fatalf("Unable to cache oauth token: %v", err)
 	}
+	defer f.Close()
 	json.NewEncoder(f).Encode(token)
 }
 

--- a/tasks/quickstart/quickstart.go
+++ b/tasks/quickstart/quickstart.go
@@ -53,7 +53,7 @@ func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
 		log.Fatalf("Unable to read authorization code: %v", err)
 	}
 
-	tok, err := config.Exchange(oauth2.NoContext, authCode)
+	tok, err := config.Exchange(context.TODO(), authCode)
 	if err != nil {
 		log.Fatalf("Unable to retrieve token from web: %v", err)
 	}


### PR DESCRIPTION
Hi! This is a slight improvement of tasks example. 

* Before closing file with defer, I checked whether open was an error. In the case of error, close processing can not be performed in some cases. 
* Use `context.TODO()` instead of `oauth2.NoContext` which is deprecated. 
  * Ref: https://godoc.org/golang.org/x/oauth2#pkg-variables

Thanks!