### PR TITLE
all: use NewService instead of New

### DIFF
--- a/admin_sdk/directory/quickstart.go
+++ b/admin_sdk/directory/quickstart.go
@@ -28,7 +28,8 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/admin/directory/v1"
+	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := admin.New(client)
+	srv, err := admin.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve directory Client %v", err)
 	}

--- a/admin_sdk/reports/quickstart.go
+++ b/admin_sdk/reports/quickstart.go
@@ -29,7 +29,8 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/admin/reports/v1"
+	admin "google.golang.org/api/admin/reports/v1"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -100,7 +101,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := admin.New(client)
+	srv, err := admin.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve reports Client %v", err)
 	}

--- a/admin_sdk/reseller/quickstart.go
+++ b/admin_sdk/reseller/quickstart.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/reseller/v1"
 )
 
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := reseller.New(client)
+	srv, err := reseller.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve reseller Client %v", err)
 	}

--- a/apps_script/execute/execute.go
+++ b/apps_script/execute/execute.go
@@ -19,13 +19,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/oauth2/google"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/script/v1"
 )
 
@@ -84,7 +86,6 @@ func saveToken(path string, token *oauth2.Token) {
 	json.NewEncoder(f).Encode(token)
 }
 
-
 func main() {
 	// [START apps_script_api_execute]
 
@@ -104,7 +105,7 @@ func main() {
 	client := getClient(config)
 
 	// Generate a service object.
-	srv, err := script.New(client)
+	srv, err := script.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve script Client %v", err)
 	}
@@ -126,7 +127,7 @@ func main() {
 		// The values of this map are the script's 'errorMessage' and
 		// 'errorType', and an array of stack trace elements (which also need to
 		// be cast as maps).
-		var details map[string]interface{};
+		var details map[string]interface{}
 		json.Unmarshal(resp.Error.Details[0], &details)
 		fmt.Printf("Script details message: %s\n", details["errorMessage"])
 
@@ -143,7 +144,7 @@ func main() {
 		// based upon what types the Apps Script function returns. Here, the
 		// function returns an Apps Script Object with String keys and values, so
 		// must be cast into a map (folderSet).
-		var r map[string]interface{};
+		var r map[string]interface{}
 		json.Unmarshal(resp.Response, &r)
 		folderSet := r["result"].(map[string]interface{})
 		if len(folderSet) == 0 {

--- a/apps_script/quickstart/quickstart.go
+++ b/apps_script/quickstart/quickstart.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/script/v1"
 )
 
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := script.New(client)
+	srv, err := script.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Script client: %v", err)
 	}

--- a/calendar/quickstart/quickstart.go
+++ b/calendar/quickstart/quickstart.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -100,7 +101,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := calendar.New(client)
+	srv, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Calendar client: %v", err)
 	}

--- a/classroom/quickstart/quickstart.go
+++ b/classroom/quickstart/quickstart.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/classroom/v1"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := classroom.New(client)
+	srv, err := classroom.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to create classroom Client %v", err)
 	}

--- a/classroom/snippets/createCourse.go
+++ b/classroom/snippets/createCourse.go
@@ -17,31 +17,34 @@
 package main
 
 import (
-        "fmt"
-        "google.golang.org/api/classroom/v1"
-        "log"
-        "net/http"
+	"fmt"
+	"log"
+	"net/http"
+
+	"golang.org/x/net/context"
+	"google.golang.org/api/classroom/v1"
+	"google.golang.org/api/option"
 )
 
 func createCourse(client *http.Client) {
-        srv, err := classroom.New(client)
-        if err != nil {
-                log.Fatalf("Unable to create classroom Client %v", err)
-        }
-        // [START classroom_create_course]
-        c := &classroom.Course{
-                Name: "10th Grade Biology",
-                Section: "Period 2",
-                DescriptionHeading: "Welcome to 10th Grade Biology",
-                Description: "We'll be learning about about the structure of living creatures from a combination of textbooks, guest lectures, and lab work. Expect to be excited!",
-                Room: "301",
-                OwnerId: "me",
-                CourseState: "PROVISIONED",
-        }
-        course, err := srv.Courses.Create(c).Do()
-        if err != nil {
-                log.Fatalf("Course unable to be created %v", err)
-        }
-        // [END classroom_create_course]
-        fmt.Printf("Created course: %v", course.Id)
+	srv, err := classroom.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		log.Fatalf("Unable to create classroom Client %v", err)
+	}
+	// [START classroom_create_course]
+	c := &classroom.Course{
+		Name:               "10th Grade Biology",
+		Section:            "Period 2",
+		DescriptionHeading: "Welcome to 10th Grade Biology",
+		Description:        "We'll be learning about about the structure of living creatures from a combination of textbooks, guest lectures, and lab work. Expect to be excited!",
+		Room:               "301",
+		OwnerId:            "me",
+		CourseState:        "PROVISIONED",
+	}
+	course, err := srv.Courses.Create(c).Do()
+	if err != nil {
+		log.Fatalf("Course unable to be created %v", err)
+	}
+	// [END classroom_create_course]
+	fmt.Printf("Created course: %v", course.Id)
 }

--- a/classroom/snippets/getCourse.go
+++ b/classroom/snippets/getCourse.go
@@ -17,40 +17,43 @@
 package main
 
 import (
-        "fmt"
-        "golang.org/x/oauth2/google"
-        "google.golang.org/api/classroom/v1"
-        "io/ioutil"
-        "log"
-        "net/http"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/classroom/v1"
+	"google.golang.org/api/option"
 )
 
 func getCourse(client *http.Client) {
-        // [START classroom_get_course]
-        srv, err := classroom.New(client)
-        if err != nil {
-                log.Fatalf("Unable to create classroom Client %v", err)
-        }
-        id := "123456"
-        course, err := srv.Courses.Get(id).Do()
-        if err != nil {
-                log.Fatalf("Course unable to be retrieved %v", err)
-        }
-        // [END classroom_get_course]
-        fmt.Printf("Course with ID %v found.", course.Id)
+	// [START classroom_get_course]
+	srv, err := classroom.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		log.Fatalf("Unable to create classroom Client %v", err)
+	}
+	id := "123456"
+	course, err := srv.Courses.Get(id).Do()
+	if err != nil {
+		log.Fatalf("Course unable to be retrieved %v", err)
+	}
+	// [END classroom_get_course]
+	fmt.Printf("Course with ID %v found.", course.Id)
 }
 
 func main() {
-        b, err := ioutil.ReadFile("credentials.json")
-        if err != nil {
-                log.Fatalf("Unable to read client secret file: %v", err)
-        }
+	b, err := ioutil.ReadFile("credentials.json")
+	if err != nil {
+		log.Fatalf("Unable to read client secret file: %v", err)
+	}
 
-        // If modifying these scopes, delete your previously saved token.json.
-        config, err := google.ConfigFromJSON(b, classroom.ClassroomCoursesScope)
-        if err != nil {
-                log.Fatalf("Unable to parse client secret file to config: %v", err)
-        }
-        client := getClient(config)
-        getCourse(client)
+	// If modifying these scopes, delete your previously saved token.json.
+	config, err := google.ConfigFromJSON(b, classroom.ClassroomCoursesScope)
+	if err != nil {
+		log.Fatalf("Unable to parse client secret file to config: %v", err)
+	}
+	client := getClient(config)
+	getCourse(client)
 }

--- a/docs/quickstart/quickstart.go
+++ b/docs/quickstart/quickstart.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/option"
 )
 
 // Retrieves a token, saves the token, then returns the generated client.
@@ -97,7 +98,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := docs.New(client)
+	srv, err := docs.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Docs client: %v", err)
 	}

--- a/drive/activity-v2/quickstart/quickstart.go
+++ b/drive/activity-v2/quickstart/quickstart.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/driveactivity/v2"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -202,7 +203,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := driveactivity.New(client)
+	srv, err := driveactivity.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve driveactivity Client %v", err)
 	}

--- a/drive/activity/quickstart/quickstart.go
+++ b/drive/activity/quickstart/quickstart.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/appsactivity/v1"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -100,7 +101,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := appsactivity.New(client)
+	srv, err := appsactivity.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve appsactivity Client %v", err)
 	}

--- a/drive/quickstart/quickstart.go
+++ b/drive/quickstart/quickstart.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := drive.New(client)
+	srv, err := drive.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Drive client: %v", err)
 	}

--- a/gmail/quickstart/quickstart.go
+++ b/gmail/quickstart/quickstart.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
 )
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := gmail.New(client)
+	srv, err := gmail.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Gmail client: %v", err)
 	}

--- a/people/quickstart/quickstart.go
+++ b/people/quickstart/quickstart.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 )
 
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := people.New(client)
+	srv, err := people.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to create people Client %v", err)
 	}

--- a/sheets/quickstart/quickstart.go
+++ b/sheets/quickstart/quickstart.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )
 
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := sheets.New(client)
+	srv, err := sheets.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Sheets client: %v", err)
 	}

--- a/slides/quickstart/quickstart.go
+++ b/slides/quickstart/quickstart.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/slides/v1"
 )
 
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := slides.New(client)
+	srv, err := slides.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Slides client: %v", err)
 	}

--- a/slides/snippets/oauth.go
+++ b/slides/snippets/oauth.go
@@ -2,9 +2,11 @@ package snippets
 
 import (
 	"log"
+
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/drive/v2"
+	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 	"google.golang.org/api/slides/v1"
 )
@@ -27,15 +29,15 @@ func getServices() *Services {
 	if err != nil {
 		log.Fatalf("Error creating Google client: %v", err)
 	}
-	driveService, err := drive.New(client)
+	driveService, err := drive.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Error creating Drive client: %v", err)
 	}
-	slidesService, err := slides.New(client)
+	slidesService, err := slides.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Error creating Slides client: %v", err)
 	}
-	sheetsService, err := sheets.New(client)
+	sheetsService, err := sheets.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Error creating Sheets client: %v", err)
 	}

--- a/slides/snippets/presentations.go
+++ b/slides/snippets/presentations.go
@@ -2,9 +2,9 @@ package snippets
 
 import (
 	"fmt"
-	"log"
 	"google.golang.org/api/drive/v2"
 	"google.golang.org/api/slides/v1"
+	"log"
 )
 
 func createPresentation() string {

--- a/tasks/quickstart/quickstart.go
+++ b/tasks/quickstart/quickstart.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 	"google.golang.org/api/tasks/v1"
 )
 
@@ -99,7 +100,7 @@ func main() {
 	}
 	client := getClient(config)
 
-	srv, err := tasks.New(client)
+	srv, err := tasks.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve tasks Client %v", err)
 	}


### PR DESCRIPTION
According to documents (e.g. [calendar](https://pkg.go.dev/google.golang.org/api/calendar/v3?tab=doc#New)), `New` is now deprecated and it is recommended to use `NewService` and provide `*http.Client` using `option.WithHTTPClient`.

Could you update?